### PR TITLE
Make workers temporary

### DIFF
--- a/Part 1: A Batch/controller.js
+++ b/Part 1: A Batch/controller.js
@@ -329,8 +329,9 @@ export async function main(ns) {
 
 	// Then we just deploy each of them. The only argument the workers get is a serialized version of the Job object.
 	// Workers themselves will parse the JSON and use that data for their own calculations. See the worker scripts for details.
+	// Worker scripts are made temporary so they aren't included in saves. This is to prevent a whole host of technical issues and speed up saving.
 	for (const job of batch) {
-		ns.exec(SCRIPTS[job.type], job.server, job.threads, JSON.stringify(job));
+		ns.exec(SCRIPTS[job.type], job.server, { threads: job.threads, temporary: true }, JSON.stringify(job));
 	}
 
 	// This is just some fancy UI stuff to give you feedback when you run the script.

--- a/Part 1: A Batch/utils.js
+++ b/Part 1: A Batch/utils.js
@@ -183,7 +183,7 @@ export async function prep(ns, values, ramNet) {
 					gThreads = 0;
 				} else break;
 				metrics.server = block.server;
-				const pid = ns.exec(script, block.server, threads, JSON.stringify(metrics));
+				const pid = ns.exec(script, block.server, { threads: threads, temporary: true }, JSON.stringify(metrics));
 				if (!pid) throw new Error("Unable to assign all jobs.");
 				block.ram -= 1.75 * threads;
 			}

--- a/Part 2: Proto-Batcher/controller.js
+++ b/Part 2: Proto-Batcher/controller.js
@@ -67,7 +67,7 @@ export async function main(ns) {
 		// We do a bit more during deployment now.
 		for (const job of batch) {
 			job.end += metrics.delay;
-			const jobPid = ns.exec(SCRIPTS[job.type], job.server, job.threads, JSON.stringify(job));
+			const jobPid = ns.exec(SCRIPTS[job.type], job.server, { threads: job.threads, temporary: true }, JSON.stringify(job));
 			if (!jobPid) throw new Error(`Unable to deploy ${job.type}`); // If the exec fails for any reason, error out.
 			/*
 			If a worker deploys late, it will communicate back how late it was, so that the other scripts can adjust.

--- a/Part 2: Proto-Batcher/utils.js
+++ b/Part 2: Proto-Batcher/utils.js
@@ -178,7 +178,7 @@ export async function prep(ns, values, ramNet) {
 					gThreads = 0;
 				} else break;
 				metrics.server = block.server;
-				const pid = ns.exec(script, block.server, threads, JSON.stringify(metrics));
+				const pid = ns.exec(script, block.server, { threads: threads, temporary: true }, JSON.stringify(metrics));
 				if (!pid) throw new Error("Unable to assign all jobs.");
 				block.ram -= 1.75 * threads;
 			}

--- a/Part 3: Shotgun/controller.js
+++ b/Part 3: Shotgun/controller.js
@@ -89,7 +89,7 @@ export async function main(ns) {
 		*/
 		for (const job of jobs) {
 			job.end += metrics.delay;
-			const jobPid = ns.exec(SCRIPTS[job.type], job.server, job.threads, JSON.stringify(job));
+			const jobPid = ns.exec(SCRIPTS[job.type], job.server, { threads: job.threads, temporary: true }, JSON.stringify(job));
 			if (!jobPid) throw new Error(`Unable to deploy ${job.type}`);
 			const tPort = ns.getPortHandle(jobPid);
 			await tPort.nextWrite();

--- a/Part 3: Shotgun/utils.js
+++ b/Part 3: Shotgun/utils.js
@@ -178,7 +178,7 @@ export async function prep(ns, values, ramNet) {
 					gThreads = 0;
 				} else break;
 				metrics.server = block.server;
-				const pid = ns.exec(script, block.server, threads, JSON.stringify(metrics));
+				const pid = ns.exec(script, block.server, { threads: threads, temporary: true }, JSON.stringify(metrics));
 				if (!pid) throw new Error("Unable to assign all jobs.");
 				block.ram -= 1.75 * threads;
 			}

--- a/Part 4: Periodic/controller.js
+++ b/Part 4: Periodic/controller.js
@@ -87,7 +87,7 @@ class ContinuousBatcher {
 		while (!this.#schedule.isEmpty()) {
 			const job = this.#schedule.shift();
 			job.end += this.#metrics.delay;
-			const jobPid = this.#ns.exec(SCRIPTS[job.type], job.server, job.threads, JSON.stringify(job));
+			const jobPid = this.#ns.exec(SCRIPTS[job.type], job.server, { threads: job.threads, temporary: true }, JSON.stringify(job));
 			if (!jobPid) throw new Error(`Unable to deploy ${job.type}`);
 			const tPort = this.#ns.getPortHandle(jobPid);
 

--- a/Part 4: Periodic/utils.js
+++ b/Part 4: Periodic/utils.js
@@ -369,7 +369,7 @@ export async function prep(ns, values, ramNet) {
 					gThreads = 0;
 				} else break;
 				metrics.server = block.server;
-				const pid = ns.exec(script, block.server, threads, JSON.stringify(metrics));
+				const pid = ns.exec(script, block.server, { threads: threads, temporary: true }, JSON.stringify(metrics));
 				if (!pid) throw new Error("Unable to assign all jobs.");
 				block.ram -= 1.75 * threads;
 			}


### PR DESCRIPTION
Workers are now temporary to prevent a host of bugs ranging from annoying to catastrophic when saving/loading files running the batcher.